### PR TITLE
Rewrite for proper comment hook

### DIFF
--- a/hook.rb
+++ b/hook.rb
@@ -12,7 +12,7 @@ post '/hook' do
   puts "Action: #{action}"
   if ['opened', 'reopened'].include? action
     pull_request = PullRequest.new payload['pull_request']
-    PivotalTracker.new(pull_request.to_commit).post!
+    PivotalTracker.new(pull_request).post!
   end
 end
 

--- a/models/pivotal_tracker.rb
+++ b/models/pivotal_tracker.rb
@@ -7,7 +7,7 @@ class PivotalTracker
 
   def self.story(story_id)
     story_path = "/stories/#{story_id}"
-    get_request = Net::HTTP::Get.new story_path, headers
+    get_request = Net::HTTP::Get.new "#{BASE_URL.path}/#{story_path}".squeeze('/'), headers
     Net::HTTP::start BASE_URL.host, BASE_URL.port, use_ssl: BASE_URL.scheme == 'https' do |http|
       response = http.request get_request
       response.body ? JSON.parse(response.body) : {}
@@ -29,6 +29,8 @@ class PivotalTracker
       story_paths.each do |story_path|
         post_comment = Net::HTTP::Post.new "#{BASE_URL.path}/#{story_path}/comments".squeeze('/'), self.class.headers
         post_comment.body = @pull_request.to_comment.to_json
+        puts "Path: #{BASE_URL.path}/#{story_path}/comments"
+        puts "Body: #{post_comment.body}"
         http.request post_comment
       end
     end

--- a/models/pivotal_tracker.rb
+++ b/models/pivotal_tracker.rb
@@ -3,12 +3,11 @@ require 'net/http'
 
 class PivotalTracker
   BASE_URL = URI 'https://www.pivotaltracker.com/services/v5/'
-  TRACKER_URL = URI 'https://www.pivotaltracker.com/services/v5/source_commits'
 
   def self.story(story_id)
-    story_path = "/stories/#{story_id}"
-    get_request = Net::HTTP::Get.new "#{BASE_URL.path}/#{story_path}".squeeze('/'), headers
-    Net::HTTP::start BASE_URL.host, BASE_URL.port, use_ssl: BASE_URL.scheme == 'https' do |http|
+    story_path = tracker_path "/stories/#{story_id}"
+    get_request = Net::HTTP::Get.new story_path, headers
+    start_tracker_session do |http|
       response = http.request get_request
       response.body ? JSON.parse(response.body) : {}
     end
@@ -22,15 +21,14 @@ class PivotalTracker
     puts "Sending to Pivotal Tracker: #{@pull_request.title}"
     story_paths = @pull_request.story_ids.collect do |story_id|
       project_id = self.class.story(story_id)['project_id']
-      project_id ? "/projects/#{project_id}/stories/#{story_id}" : nil
+      project_id ? self.class.tracker_path("/projects/#{project_id}/stories/#{story_id}/comments") : nil
     end.compact
 
-    Net::HTTP::start BASE_URL.host, BASE_URL.port, use_ssl: BASE_URL.scheme == 'https' do |http|
+    self.class.start_tracker_session do |http|
       story_paths.each do |story_path|
-        post_comment = Net::HTTP::Post.new "#{BASE_URL.path}/#{story_path}/comments".squeeze('/'), self.class.headers
+        post_comment = Net::HTTP::Post.new story_path, self.class.headers
         post_comment.body = @pull_request.to_comment.to_json
-        puts "Path: #{BASE_URL.path}/#{story_path}/comments"
-        puts "Body: #{post_comment.body}"
+        puts "Path: #{story_path}, body: #{post_comment.body}"
         http.request post_comment
       end
     end
@@ -38,10 +36,20 @@ class PivotalTracker
 
   private
 
-  def self.headers
-    @headers ||= {
-      'Content-Type' => 'application/json',
-      'X-TrackerToken' => ENV['PIVOTAL_TRACKER_API_TOKEN']
-    }
+  class << self
+    def start_tracker_session(&block)
+        Net::HTTP::start BASE_URL.host, BASE_URL.port, use_ssl: BASE_URL.scheme == 'https', &block
+    end
+
+    def headers
+      @headers ||= {
+        'Content-Type' => 'application/json',
+        'X-TrackerToken' => ENV['PIVOTAL_TRACKER_API_TOKEN']
+      }
+    end
+
+    def tracker_path(path)
+      "#{BASE_URL.path}/#{path}".squeeze('/')
+    end
   end
 end

--- a/models/pivotal_tracker.rb
+++ b/models/pivotal_tracker.rb
@@ -1,7 +1,18 @@
+require 'json'
 require 'net/http'
 
 class PivotalTracker
+  BASE_URL = URI 'https://www.pivotaltracker.com/services/v5/'
   TRACKER_URL = URI 'https://www.pivotaltracker.com/services/v5/source_commits'
+
+  def self.story(story_id)
+    story_path = "/stories/#{story_id}"
+    get_request = Net::HTTP::Get.new story_path, headers
+    Net::HTTP::start BASE_URL.host, BASE_URL.port, use_ssl: BASE_URL.scheme == 'https' do |http|
+      response = http.request get_request
+      response.body ? JSON.parse(response.body) : {}
+    end
+  end
 
   def initialize(post_data)
     @post_data = post_data

--- a/models/pull_request.rb
+++ b/models/pull_request.rb
@@ -8,17 +8,6 @@ class PullRequest < OpenStruct
   end
 
 
-  def to_commit
-    {
-      source_commit: {
-        author: user['login'],
-        commit_id: "pulls/#{number}",
-        message: "Created pull request: #{title}",
-        url: html_url
-      }
-    }
-  end
-
   def to_comment
     {
       commit_type: 'github',

--- a/models/pull_request.rb
+++ b/models/pull_request.rb
@@ -1,6 +1,13 @@
 require 'ostruct'
 
 class PullRequest < OpenStruct
+  def story_ids
+    title.scan(%r{\[.*?\]}).collect do |brackets|
+      brackets.scan %r{#(\d+)}
+    end.flatten
+  end
+
+
   def to_commit
     {
       source_commit: {

--- a/models/pull_request.rb
+++ b/models/pull_request.rb
@@ -9,9 +9,6 @@ class PullRequest < OpenStruct
 
 
   def to_comment
-    {
-      commit_type: 'github',
-      text: "#{user['login']} created pull request [##{number}: #{title}](#{html_url})"
-    }
+    {text: "#{user['login']} created pull request [##{number}: #{title}](#{html_url})"}
   end
 end

--- a/models/pull_request.rb
+++ b/models/pull_request.rb
@@ -11,4 +11,11 @@ class PullRequest < OpenStruct
       }
     }
   end
+
+  def to_comment
+    {
+      commit_type: 'github',
+      text: "#{user['login']} created pull request [##{number}: #{title}](#{html_url})"
+    }
+  end
 end

--- a/spec/unit/pivotal_tracker_spec.rb
+++ b/spec/unit/pivotal_tracker_spec.rb
@@ -8,26 +8,51 @@ describe PivotalTracker do
     end
   end
 
-  describe '#post!' do
-    let(:data) { Hash[*(1..3).collect { [Faker::Lorem.words(1), Faker::Lorem.sentence] }.flatten] }
-    let(:post!) { PivotalTracker.new(data).post! }
-    let!(:tracker_request) { stub_request :post, tracker_endpoint }
-    let(:tracker_endpoint) { PivotalTracker::TRACKER_URL }
+  context 'requests' do
+    let(:api_token) { ENV['PIVOTAL_TRACKER_API_TOKEN'] }
 
-    it "posts the object's data to Pivotal Tracker as JSON" do
-      post!
-      expect(tracker_request.with body: data.to_json).to have_been_requested
+    describe '.story' do
+      let(:request!) { PivotalTracker.story story_id }
+      let(:story_id) { rand 1_000_000..1_000_000_000 }
+      let!(:story_request) { stub_request :get, URI.join(PivotalTracker::BASE_URL, "/stories/#{story_id}") }
+
+
+      it 'requests the Tracker data for the given story ID' do
+        request!
+        expect(story_request).to have_been_made
+      end
+
+      it 'uses standard headers in the request' do
+        request!
+        expect(story_request.with headers: {'Content-Type' => 'application/json', 'X-TrackerToken' => api_token}).to have_been_made
+      end
+
+      it 'returns the response body parsed as JSON' do
+        story_request.to_return body: '{"foo": 1, "bar": "baz"}', headers: {'Content-Type' => 'application/json'}
+        expect(request!).to be == {'foo' => 1, 'bar' => 'baz'}
+      end
     end
 
-    it "sets the request's content type to JSON" do
-      post!
-      expect(tracker_request.with headers: {'Content-Type' => 'application/json'}).to have_been_requested
-    end
+    describe '#post!' do
+      let(:data) { Hash[*(1..3).collect { [Faker::Lorem.words(1), Faker::Lorem.sentence] }.flatten] }
+      let(:post!) { PivotalTracker.new(data).post! }
+      let!(:tracker_request) { stub_request :post, tracker_endpoint }
+      let(:tracker_endpoint) { PivotalTracker::TRACKER_URL }
 
-    it 'sends the Pivotal Tracker API token from the environment' do
-      api_token = ENV['PIVOTAL_TRACKER_API_TOKEN']
-      post!
-      expect(tracker_request.with headers: {'X-TrackerToken' => api_token}).to have_been_requested
+      it "posts the object's data to Pivotal Tracker as JSON" do
+        post!
+        expect(tracker_request.with body: data.to_json).to have_been_requested
+      end
+
+      it "sets the request's content type to JSON" do
+        post!
+        expect(tracker_request.with headers: {'Content-Type' => 'application/json'}).to have_been_requested
+      end
+
+      it 'sends the Pivotal Tracker API token from the environment' do
+        post!
+        expect(tracker_request.with headers: {'X-TrackerToken' => api_token}).to have_been_requested
+      end
     end
   end
 end

--- a/spec/unit/pivotal_tracker_spec.rb
+++ b/spec/unit/pivotal_tracker_spec.rb
@@ -15,7 +15,7 @@ describe PivotalTracker do
     describe '.story' do
       let(:request!) { PivotalTracker.story story_id }
       let(:story_id) { rand 1_000_000..1_000_000_000 }
-      let!(:story_request) { stub_request :get, URI.join(PivotalTracker::BASE_URL, "/stories/#{story_id}") }
+      let!(:story_request) { stub_request :get,  "#{PivotalTracker::BASE_URL}stories/#{story_id}" }
 
 
       it 'requests the Tracker data for the given story ID' do
@@ -41,7 +41,7 @@ describe PivotalTracker do
         story_ids = (1..3).collect { rand(1000).to_s }
         project_ids = story_ids.zip (1..3).collect { rand(1000).to_s }
         project_ids.each do |story_id, project_id|
-          stub_request(:get, URI.join(PivotalTracker::BASE_URL, "/stories/#{story_id}")).to_return body: {project_id: project_id}.to_json
+          stub_request(:get, "#{PivotalTracker::BASE_URL}stories/#{story_id}").to_return body: {project_id: project_id}.to_json
         end
         allow(pull_request).to receive(:story_ids).and_return story_ids
         comment = {text: Faker::Lorem.sentence}

--- a/spec/unit/pull_request_spec.rb
+++ b/spec/unit/pull_request_spec.rb
@@ -8,6 +8,57 @@ describe PullRequest do
     end
   end
 
+  describe '#story_ids' do
+    let(:story_id) { random_story_id }
+
+    subject { PullRequest.new(title: title).story_ids }
+
+    context 'no story ID' do
+      let(:title) { Faker::Lorem.sentence }
+
+      it 'returns an empty array' do
+        expect(subject).to be == []
+      end
+    end
+
+    context 'story ID without #' do
+      let(:title) { "[#{story_id}] Faker::Lorem.sentence" }
+
+      it 'returns an empty array' do
+        expect(subject).to be == []
+      end
+    end
+
+    context 'story ID at the beginning' do
+      let(:title) { "[##{story_id}] #{Faker::Lorem.sentence}" }
+
+      it 'returns the story ID' do
+        expect(subject).to be == [story_id.to_s]
+      end
+    end
+
+    context 'multiple story IDs' do
+      let(:story_ids) { (1..3).collect { random_story_id} }
+      let(:title) { "#{ids_string} #{Faker::Lorem.sentence}" }
+
+      context 'separate brackets' do
+        let(:ids_string) { story_ids.collect {|id| "[##{id}]" }.join ' ' }
+
+        it 'returns all the story IDs' do
+          expect(subject).to match_array story_ids.collect(&:to_s)
+        end
+      end
+
+      context 'same brackets' do
+        let(:ids_string) { "[#{story_ids.collect {|id| "##{id}" }.join ','}]"}
+
+        it 'returns all the story IDs' do
+          expect(subject).to match_array story_ids.collect(&:to_s)
+        end
+      end
+    end
+  end
+
   describe '#to_comment' do
     let(:data) do
       {
@@ -71,4 +122,8 @@ describe PullRequest do
       expect(subject[:url]).to be == html_url
     end
   end
+end
+
+def random_story_id
+  rand 1000_000..1_000_000_000
 end

--- a/spec/unit/pull_request_spec.rb
+++ b/spec/unit/pull_request_spec.rb
@@ -84,44 +84,6 @@ describe PullRequest do
       expect(subject[:commit_type]).to be == 'github'
     end
   end
-
-  describe '#to_commit' do
-    let(:data) do
-      {
-        'html_url' => html_url,
-        'number' => number,
-        'title' => title,
-        'user' => {'login' => login}
-      }
-    end
-    let(:html_url) { Faker::Internet.url }
-    let(:login) { Faker::Internet.user_name }
-    let(:number) { rand 1..1000 }
-    let(:pull_request) { PullRequest.new data }
-    let(:title) { Faker::Lorem.sentence }
-
-    subject { pull_request.to_commit[:source_commit] }
-
-    it 'wraps the whole thing in a source_commit key' do
-      expect(pull_request.to_commit.keys).to be == [:source_commit]
-    end
-
-    it 'exports the login name as the author' do
-      expect(subject[:author]).to be == login
-    end
-
-    it 'exports the number as the commit ID' do
-      expect(subject[:commit_id]).to be == "pulls/#{number}"
-    end
-
-    it 'exports the title in the message field, with prefix' do
-      expect(subject[:message]).to be == "Created pull request: #{title}"
-    end
-
-    it 'exports the URL' do
-      expect(subject[:url]).to be == html_url
-    end
-  end
 end
 
 def random_story_id

--- a/spec/unit/pull_request_spec.rb
+++ b/spec/unit/pull_request_spec.rb
@@ -8,7 +8,33 @@ describe PullRequest do
     end
   end
 
-  describe '.to_commit' do
+  describe '#to_comment' do
+    let(:data) do
+      {
+        'html_url' => html_url,
+        'number' => number,
+        'title' => title,
+        'user' => {'login' => login}
+      }
+    end
+    let(:html_url) { Faker::Internet.url }
+    let(:login) { Faker::Internet.user_name }
+    let(:number) { rand 1..1000 }
+    let(:pull_request) { PullRequest.new data }
+    let(:title) { Faker::Lorem.sentence }
+
+    subject { pull_request.to_comment }
+
+    it 'converts the pull request data to a string' do
+      expect(subject[:text]).to be == "#{login} created pull request [##{number}: #{title}](#{html_url})"
+    end
+
+    it 'identifies the comment as coming from GitHub' do
+      expect(subject[:commit_type]).to be == 'github'
+    end
+  end
+
+  describe '#to_commit' do
     let(:data) do
       {
         'html_url' => html_url,

--- a/spec/unit/pull_request_spec.rb
+++ b/spec/unit/pull_request_spec.rb
@@ -79,10 +79,6 @@ describe PullRequest do
     it 'converts the pull request data to a string' do
       expect(subject[:text]).to be == "#{login} created pull request [##{number}: #{title}](#{html_url})"
     end
-
-    it 'identifies the comment as coming from GitHub' do
-      expect(subject[:commit_type]).to be == 'github'
-    end
   end
 end
 


### PR DESCRIPTION
It turns out that we can make this a real comment and not have to hack it through the Git commit endpoint.