### PR TITLE
Add the base label in the to_comment method

### DIFF
--- a/models/pull_request.rb
+++ b/models/pull_request.rb
@@ -9,6 +9,6 @@ class PullRequest < OpenStruct
 
 
   def to_comment
-    {text: "#{user['login']} created pull request [##{number}: #{title}](#{html_url})"}
+    {text: "#{user['login']} created pull request [##{number}: #{title}](#{html_url}) to #{base['label']} "}
   end
 end

--- a/spec/integration/hook_spec.rb
+++ b/spec/integration/hook_spec.rb
@@ -21,11 +21,13 @@ describe 'webhook' do
           html_url: html_url,
           number: pull_number,
           title: title,
-          user: {login: login}
+          user: {login: login},
+          base: {label: base_label}          
         }
       end
       let(:story_id) { rand 1..10000 }
       let(:title) { "[##{story_id}] #{Faker::Lorem.sentence}" }
+      let(:base_label) { Faker::Hacker.abbreviation }
 
       before(:each) do
         expect_any_instance_of(app).to receive(:verify_signature).and_return true
@@ -33,7 +35,7 @@ describe 'webhook' do
       end
 
       it 'posts the pull request title to Pivotal Tracker as a comment message' do
-        request = stub_json_request :post, %r{^#{Regexp.escape tracker_base_url}projects/\d+/stories/\d+/comments$}, with: {'text' => "#{login} created pull request [##{pull_number}: #{title}](#{html_url})"}
+        request = stub_json_request :post, %r{^#{Regexp.escape tracker_base_url}projects/\d+/stories/\d+/comments$}, with: {'text' => "#{login} created pull request [##{pull_number}: #{title}](#{html_url}) to #{base_label} "}
         post!
         expect(request).to have_been_made
       end

--- a/spec/unit/pull_request_spec.rb
+++ b/spec/unit/pull_request_spec.rb
@@ -65,7 +65,8 @@ describe PullRequest do
         'html_url' => html_url,
         'number' => number,
         'title' => title,
-        'user' => {'login' => login}
+        'user' => {'login' => login},
+        'base' => {'label' => base_label}
       }
     end
     let(:html_url) { Faker::Internet.url }
@@ -73,11 +74,12 @@ describe PullRequest do
     let(:number) { rand 1..1000 }
     let(:pull_request) { PullRequest.new data }
     let(:title) { Faker::Lorem.sentence }
+    let(:base_label) { Faker::Hacker.abbreviation }
 
     subject { pull_request.to_comment }
 
     it 'converts the pull request data to a string' do
-      expect(subject[:text]).to be == "#{login} created pull request [##{number}: #{title}](#{html_url})"
+      expect(subject[:text]).to be == "#{login} created pull request [##{number}: #{title}](#{html_url}) to #{base_label} "
     end
   end
 end


### PR DESCRIPTION
This should add the info about to which branch we are doing the PR (if not it will be pretty close).

I couldn't do the full integration (live github and pivotal) because I didn´t have enough time. Could you test the integration?